### PR TITLE
vhost-user configuration option

### DIFF
--- a/neutron/conf/plugins/ml2/drivers/ovs_conf.py
+++ b/neutron/conf/plugins/ml2/drivers/ovs_conf.py
@@ -145,6 +145,16 @@ agent_opts = [
 ]
 
 
+vhost_opts = [
+    cfg.BoolOpt('vhost_user_enabled', default=True,
+               help=_('Enable vhost-user backed virtio devices'))
+]
+
+
 def register_ovs_agent_opts(cfg=cfg.CONF):
     cfg.register_opts(ovs_opts, "OVS")
     cfg.register_opts(agent_opts, "AGENT")
+
+
+def register_ovs_vhost_opts(cfg=cfg.CONF):
+    cfg.register_opts(vhost_opts, "vhost")

--- a/neutron/plugins/ml2/drivers/openvswitch/mech_driver/mech_openvswitch.py
+++ b/neutron/plugins/ml2/drivers/openvswitch/mech_driver/mech_openvswitch.py
@@ -23,6 +23,7 @@ from oslo_config import cfg
 from oslo_log import log
 
 from neutron.agent import securitygroups_rpc
+from neutron.conf.plugins.ml2.drivers import ovs_conf
 from neutron.plugins.common import constants as p_constants
 from neutron.plugins.ml2.drivers import mech_agent
 from neutron.plugins.ml2.drivers.openvswitch.agent.common \
@@ -33,6 +34,9 @@ LOG = log.getLogger(__name__)
 
 IPTABLES_FW_DRIVER_FULL = ("neutron.agent.linux.iptables_firewall."
                            "OVSHybridIptablesFirewallDriver")
+
+
+ovs_conf.register_ovs_vhost_opts(cfg.CONF)
 
 
 class OpenvswitchMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
@@ -96,7 +100,8 @@ class OpenvswitchMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                 in [a_const.OVS_DPDK_VHOST_USER,
                     a_const.OVS_DPDK_VHOST_USER_CLIENT]) and
             agent['configurations'].get('datapath_type') ==
-            a_const.OVS_DATAPATH_NETDEV):
+            a_const.OVS_DATAPATH_NETDEV and
+            cfg.CONF.vhost.vhost_user_enabled):
             return portbindings.VIF_TYPE_VHOST_USER
         return self.vif_type
 


### PR DESCRIPTION
Introduces a configuration option to be able to specify whether
vhost-user VIF type should be configured.  This permits the
configuration to override the derived datapath type of OVS which is
required in environments that run a user-space datapath (netdev) but
cannot support vhost-user backends (e.g. nested virtual environments).

Signed-off-by: Matt Peters <matt.peters@windriver.com>
Story: 2002566