### PR TITLE
Endpoint support for VxLAN managed type driver

### DIFF
--- a/neutron/plugins/wrs/drivers/type_generic.py
+++ b/neutron/plugins/wrs/drivers/type_generic.py
@@ -32,7 +32,7 @@ from neutron.common import exceptions as n_exc
 from neutron.db import api as db_api
 from neutron.db import providernet_db as pnet_db
 from neutron.plugins.ml2 import driver_api as api
-from neutron.plugins.ml2.drivers import helpers
+
 
 LOG = logging.getLogger(__name__)
 
@@ -81,8 +81,7 @@ class GenericProvidernetTypeDriverMixin(object):
             return False
 
 
-class GenericRangeTypeDriver(helpers.SegmentTypeDriver,
-                             GenericProvidernetTypeDriverMixin):
+class GenericRangeTypeDriverMixin(GenericProvidernetTypeDriverMixin):
     """
     Manages allocation state for any segmentation id range based type
     drivers.  Only appropriate for WRS based classes that support the concept
@@ -95,10 +94,6 @@ class GenericRangeTypeDriver(helpers.SegmentTypeDriver,
         self.segmentation_key
 
     """
-
-    def __init__(self, model):
-        super(GenericRangeTypeDriver, self).__init__(model)
-
     @abc.abstractmethod
     def get_segmentation_key(self):
         """

--- a/neutron/plugins/wrs/drivers/type_managed_flat.py
+++ b/neutron/plugins/wrs/drivers/type_managed_flat.py
@@ -30,8 +30,8 @@ from neutron.plugins.wrs.drivers import type_generic
 LOG = logging.getLogger(__name__)
 
 
-class ManagedFlatTypeDriver(type_flat.FlatTypeDriver,
-                            type_generic.GenericProvidernetTypeDriverMixin):
+class ManagedFlatTypeDriver(type_generic.GenericProvidernetTypeDriverMixin,
+                            type_flat.FlatTypeDriver):
 
     def __init__(self):
         super(ManagedFlatTypeDriver, self).__init__()

--- a/neutron/plugins/wrs/drivers/type_managed_vlan.py
+++ b/neutron/plugins/wrs/drivers/type_managed_vlan.py
@@ -25,12 +25,14 @@ from neutron.plugins.common import utils
 
 from neutron.db.models.plugins.ml2 import vlanallocation as vlan_alloc_model
 from neutron.objects.plugins.ml2 import vlanallocation as vlanalloc
+from neutron.plugins.ml2.drivers import helpers
 from neutron.plugins.wrs.drivers import type_generic
 
 LOG = logging.getLogger(__name__)
 
 
-class ManagedVlanTypeDriver(type_generic.GenericRangeTypeDriver):
+class ManagedVlanTypeDriver(type_generic.GenericRangeTypeDriverMixin,
+                            helpers.SegmentTypeDriver):
     """The class is a refinement of the default VLAN type driver.
 
     Its purpose is to allocate VLAN segments based on the enhanced provider


### PR DESCRIPTION
Add endpoint management to the ManagedVxlanTypeDriver to support using
Open vSwitch as the ML2 mechanism driver.

Signed-off-by: Matt Peters <matt.peters@windriver.com>