### PR TITLE
Fixes to make neutron work with MySQL/MariaDB

### DIFF
--- a/neutron/db/migration/alembic_migrations/versions/pike/expand/wrs_11a84c4cea76_vxlan_mode_column.py
+++ b/neutron/db/migration/alembic_migrations/versions/pike/expand/wrs_11a84c4cea76_vxlan_mode_column.py
@@ -36,4 +36,5 @@ def upgrade():
                   sa.Column('mode', sa.String(8), nullable=False,
                             default=n_const.PROVIDERNET_VXLAN_DYNAMIC,
                             server_default=n_const.PROVIDERNET_VXLAN_DYNAMIC))
-    op.alter_column('providernet_range_vxlans', 'group', nullable=True)
+    op.alter_column('providernet_range_vxlans', 'group',
+                    existing_type=sa.String(length=64), nullable=True)

--- a/neutron/db/migration/alembic_migrations/versions/wrs_kilo_shipped/expand/3c52bf0d97f3_vxlan_provider_networks.py
+++ b/neutron/db/migration/alembic_migrations/versions/wrs_kilo_shipped/expand/3c52bf0d97f3_vxlan_provider_networks.py
@@ -37,7 +37,7 @@ def upgrade():
         sa.Column('vxlan_vni',
                   sa.Integer(), autoincrement=False, nullable=False),
         sa.Column('allocated',
-                  sa.Boolean(), server_default='false', nullable=False),
+                  sa.Boolean(), server_default=sa.sql.false(), nullable=False),
         sa.PrimaryKeyConstraint('physical_network', 'vxlan_vni')
     )
     op.create_table(

--- a/neutron/db/migration/alembic_migrations/versions/wrs_kilo_shipped/expand/5018b7ad4223_ml2_subnet_segment_dynamic_field.py
+++ b/neutron/db/migration/alembic_migrations/versions/wrs_kilo_shipped/expand/5018b7ad4223_ml2_subnet_segment_dynamic_field.py
@@ -36,7 +36,7 @@ def upgrade():
     op.add_column(
         'ml2_subnet_segments',
         sa.Column('is_dynamic',
-                  sa.Boolean(), server_default='false', nullable=False))
+                  sa.Boolean(), server_default=sa.sql.false(), nullable=False))
     op.add_column(
         'ml2_subnet_segments',
         sa.Column('segment_index', sa.Integer(), nullable=False,

--- a/neutron/db/migration/alembic_migrations/versions/wrs_mitaka/expand/ca1fb1471d20_provider_network_table_updates.py
+++ b/neutron/db/migration/alembic_migrations/versions/wrs_mitaka/expand/ca1fb1471d20_provider_network_table_updates.py
@@ -24,6 +24,7 @@ Create Date: 2016-05-30 00:00:01.000000
 """
 
 from alembic import op
+import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
@@ -34,7 +35,8 @@ down_revision = 'f3ead3dada66'
 def upgrade():
     # The original feature code specified the NULL constraint differently on
     # the DB migration and DB model definitions.
-    op.alter_column('providernets', 'vlan_transparent', nullable=False)
+    op.alter_column('providernets', 'vlan_transparent',
+                    existing_type=sa.Boolean(), nullable=False)
 
     # The original feature code had a descrepancy between the DB model (which
     # has an index on tenant-id), and the DB migration code which did not have

--- a/tox.ini
+++ b/tox.ini
@@ -3,21 +3,20 @@ envlist = docs,py35,py27,pep8
 minversion = 2.3.2
 skipsdist = True
 
-[wrs]
+[stx]
 # This configuration assumes that the tox tests are being run directly within
 # the build tree therefore the {toxinitdir} variable points to a path within
 # the source tree.  For example:
 #    {MY_REPO}/addons/wr-cgcs/layers/cgcs/git/neutron
 #
-wrsdir = {toxinidir}/../../../../../..
-cgcsdir = {[wrs]wrsdir}/addons/wr-cgcs/layers/cgcs
-avsdir = {[wrs]wrsdir}/addons/wr-avs/layers/avs/
-sfcdir = {[wrs]wrsdir}/addons/wr-cgcs/layers/cgcs/git/networking-sfc
-deps = -e{[wrs]cgcsdir}/middleware/fault/recipes-common/fm-api
-       -e{[wrs]cgcsdir}/middleware/sysinv/recipes-common/cgts-client/cgts-client
-       -e{[wrs]cgcsdir}/middleware/config/recipes-common/tsconfig/tsconfig
-       -e{[wrs]sfcdir}
-       -e{[wrs]avsdir}/python-vswitchclient
+stxdir = {toxinidir}/../..
+#cgcsdir = {[wrs]wrsdir}/addons/wr-cgcs/layers/cgcs
+
+deps = -e{[stx]stxdir}/stx-fault/fm-api
+       -e{[stx]stxdir}/stx-config/sysinv/cgts-client/cgts-client
+       -e{[stx]stxdir}/stx-update/tsconfig/tsconfig
+#       -e{[stx]stxdir}/git/networking-sfc
+#       -e{[stx]avsdir}/python-vswitchclient
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
@@ -29,7 +28,7 @@ install_command =
     pip install -U -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/pike} {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-       {[wrs]deps}
+       {[stx]deps}
 whitelist_externals = sh
 commands =
   {toxinidir}/tools/ostestr_compat_shim.sh {posargs}


### PR DESCRIPTION
Some of the SQL syntax added by Wind River does not work with MySQL/MariaDB.
This change updates those schemas so they are compatable in mysql without breaking postgres syntax.
These tests have been verified in a container running with MariaDB.
@Joseph,  please review these changes
