### PR TITLE
Remove stx prefix in dependencies folder name.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,9 @@ skipsdist = True
 stxdir = {toxinidir}/../..
 #cgcsdir = {[wrs]wrsdir}/addons/wr-cgcs/layers/cgcs
 
-deps = -e{[stx]stxdir}/stx-fault/fm-api
-       -e{[stx]stxdir}/stx-config/sysinv/cgts-client/cgts-client
-       -e{[stx]stxdir}/stx-update/tsconfig/tsconfig
+deps = -e{[stx]stxdir}/fault/fm-api
+       -e{[stx]stxdir}/config/sysinv/cgts-client/cgts-client
+       -e{[stx]stxdir}/update/tsconfig/tsconfig
 #       -e{[stx]stxdir}/git/networking-sfc
 #       -e{[stx]avsdir}/python-vswitchclient
 


### PR DESCRIPTION
Change required to enable tox execution after the migration to opendev.org 

Signed-off-by: Erich Cordoba <erich.cordoba.malibran@intel.com>